### PR TITLE
Disable Dockerfile updates for postgres and postgis

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,16 @@
   "prConcurrentLimit": 3,
   "packageRules": [
     {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "postgis",
+        "postgres"
+      ],
+      "enabled": false
+    },
+    {
       "matchManagers": [
         "npm"
       ],


### PR DESCRIPTION
Stop Docker updates for postgres and postgis.  Too major of a change for automation.