### PR TITLE
Disable dependency dashboards

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   "platform": "github",
   "includeForks": false,
   "configMigration": true,
-  "dependencyDashboard": true,
+  "dependencyDashboard": false,
   "prCreation": "not-pending",
   "rebaseWhen": "behind-base-branch",
   "repositories": [


### PR DESCRIPTION
Dependency Dashboards have been a dud.  Teams aren't checking, so updates are sitting unapproved.  It's better to get those out the door.