### PR TITLE
feat: allow major updates through

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -103,6 +103,13 @@
       "groupName": "testing-library"
     },
     {
+      "description": "Group @nestjs packages",
+      "matchPackagePatterns": [
+        "^@nestjs\\/"
+      ],
+      "groupName": "nestjs"
+    },
+    {
       "description": "Group @types packages",
       "matchPackagePatterns": [
         "^@types\\/"

--- a/renovate.json
+++ b/renovate.json
@@ -105,7 +105,8 @@
     {
       "description": "Group @nestjs packages",
       "matchPackagePatterns": [
-        "^@nestjs\\/"
+        "^@nestjs\\/",
+        "nest-winston"
       ],
       "groupName": "nestjs"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -70,14 +70,6 @@
       "stabilityDays": 3
     },
     {
-      "description": "Require dashboard approval for major updates",
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "dependencyDashboardApproval": true,
-      "stabilityDays": 3
-    },
-    {
       "description": "Groupe vite packages",
       "groupName": "vite",
       "matchPackagePatterns": [


### PR DESCRIPTION
Disabling the dependency dashboard wasn't enough and major updates still aren't getting through automatically.  This PR should solve that.