### PR TITLE
feat: limit PR dry runs to only two repos + action update

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,6 +24,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           cat <<< $(jq '.+= {"dryRun": "full"}' ${{ env.config }}) > ${{ env.config }}
+          cat <<< $(jq '(.repositories) |= "['"'bcgov/nr-renovate'"', '"'bcgov/openshift-quickstart'"']"' ${{ env.config }}) > ${{ env.config }}
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v34.149.0

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,9 +23,8 @@ jobs:
       - name: Set dry run and repo list
         if: github.event_name == 'pull_request'
         env:
-          repos: '["bcgov/nr-renovate", "bcgov/quickstart-openshift"]'
+          repos: '["bcgov/nr-renovate"]'
         run: |
-          cat <<< $(jq '.+= {"dryRun": "full"}' ${{ env.config }}) > ${{ env.config }}
           cat <<< $(jq '. | .repositories = ${{ env.repos }}' ${{ env.config }}) > ${{ env.config }}
 
       - name: Self-hosted Renovate

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,8 +23,9 @@ jobs:
       - name: Dry run for PRs
         if: github.event_name == 'pull_request'
         run: |
-          cat <<< $(jq '.+= {"dryRun": "full"}' ${{ env.config }}) > ${{ env.config }}
-          cat <<< $(jq '(.repositories) |= "['"'bcgov/nr-renovate'"', '"'bcgov/openshift-quickstart'"']"' ${{ env.config }}) > ${{ env.config }}
+          cat <<< $(jq '.+= {"dryRun": "full"} | \
+            .repositories) |= "['"'bcgov/nr-renovate'"', '"'bcgov/openshift-quickstart'"']"' \
+            ${{ env.config }}) > ${{ env.config }}
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v34.149.0

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,12 +23,14 @@ jobs:
       - name: Set dry run and repo list
         if: github.event_name == 'pull_request'
         env:
-          repos: '["bcgov/nr-renovate"]'
+          repos: '["bcgov/nr-renovate", "bcgov/quickstart-openshift"]'
         run: |
+          cat <<< $(jq '.+= {"dryRun": "full"}' ${{ env.config }}) > ${{ env.config }}
           cat <<< $(jq '. | .repositories = ${{ env.repos }}' ${{ env.config }}) > ${{ env.config }}
+          cat ${{ env.config }} | jq .repositories
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v34.149.0
+        uses: renovatebot/github-action@v39.0.1
         with:
           configurationFile: ${{ env.config }}
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # PRs should always use dry run
-      - name: Dry run for PRs
+      - name: Set dry run and repo list
         if: github.event_name == 'pull_request'
         env:
           repos: '["bcgov/nr-renovate", "bcgov/quickstart-openshift"]'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,10 +22,11 @@ jobs:
       # PRs should always use dry run
       - name: Dry run for PRs
         if: github.event_name == 'pull_request'
+        env:
+          repos: '["bcgov/nr-renovate", "bcgov/quickstart-openshift"]'
         run: |
-          cat <<< $(jq '.+= {"dryRun": "full"} | \
-            .repositories) |= "['"'bcgov/nr-renovate'"', '"'bcgov/openshift-quickstart'"']"' \
-            ${{ env.config }}) > ${{ env.config }}
+          cat <<< $(jq '.+= {"dryRun": "full"}' ${{ env.config }}) > ${{ env.config }}
+          cat <<< $(jq '. | .repositories = ${{ env.repos }}' ${{ env.config }}) > ${{ env.config }}
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v34.149.0

--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,7 @@
     "bcgov/nr-forests-access-management",
     "bcgov/nr-old-growth",
     "bcgov/nr-oracle-service",
+    "bcgov/nr-renovate",
     "bcgov/nr-rfc-grib-copy",
     "bcgov/nr-rfc-processing",
     "bcgov/nr-spar",


### PR DESCRIPTION
Reduce the number of repos scanned in PRs.  This is always a dry-run, so no actual functionality is changed.