### PR TITLE
feat: add concurrency and stop running on main merge

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,21 +1,22 @@
 name: Renovate
 on:
   pull_request:
-  push:
-    branches:
-      - main
   schedule:
     - cron: "0 11 * * *" # 3 AM PST = 11 AM UDT
   workflow_dispatch:
 
-env:
-  config: renovate.json
+# PR open and close use the same group, allowing only one at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   renovate:
-    runs-on: ubuntu-22.04
+    env:
+      config: renovate.json
     permissions:
       pull-requests: write
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Prevent multiple workflow runs from the same source (PR, dispatch, cronjob).  Prevent running on merge to main, since nightly cronjobs are the expected plan.

Note: Renovate is a pretty large job.  Non-shortened configurations chew up a runner for over 10 minutes.