### PR TITLE
feat: workflow_dispatch single repo option

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 11 * * *" # 3 AM PST = 11 AM UDT
   workflow_dispatch:
+    inputs:
+      repository:
+        description: optional single org/repo to run against
+        type: string
+        required: false
 
 # PR open and close use the same group, allowing only one at a time
 concurrency:
@@ -20,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # PRs should always use dry run
+      # PRs - dry run and a small number of repos
       - name: Set dry run and repo list
         if: github.event_name == 'pull_request'
         env:
@@ -30,6 +35,14 @@ jobs:
           cat <<< $(jq '. | .repositories = ${{ env.repos }}' ${{ env.config }}) > ${{ env.config }}
           cat ${{ env.config }} | jq .repositories
 
+      # workflow_dispatch - optionally just one repo
+      - name: Set dry run and repo list
+        if: inputs.repository
+        run: |
+          cat <<< $(jq '. | .repositories = ["${{ inputs.repository }}"]' ${{ env.config }}) > ${{ env.config }}
+          cat ${{ env.config }} | jq .repositories
+
+      # Run Renovate
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v39.0.1
         with:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,11 +1,13 @@
 name: Renovate
+
+# Run on pull requests, cronjob or manually (dispatch)
 on:
   pull_request:
   schedule:
     - cron: "0 11 * * *" # 3 AM PST = 11 AM UDT
   workflow_dispatch:
     inputs:
-      repo:
+      repo: # Optional input
         description: org/repo override (optional)
         type: string
         required: false
@@ -15,10 +17,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Variables
+env:
+  config: renovate.json
+  pr_repos: '["bcgov/nr-renovate", "bcgov/quickstart-openshift"]'
+
 jobs:
-  renovate:
-    env:
-      config: renovate.json
+  Renovate:
     permissions:
       pull-requests: write
     runs-on: ubuntu-22.04
@@ -28,11 +33,9 @@ jobs:
       # PRs - dry run and a small number of repos
       - name: Config for pull requests
         if: github.event_name == 'pull_request'
-        env:
-          repos: '["bcgov/nr-renovate", "bcgov/quickstart-openshift"]'
         run: |
           cat <<< $(jq '.+= {"dryRun": "full"}' ${{ env.config }}) > ${{ env.config }}
-          cat <<< $(jq '. | .repositories = ${{ env.repos }}' ${{ env.config }}) > ${{ env.config }}
+          cat <<< $(jq '. | .repositories = ${{ env.pr_repos }}' ${{ env.config }}) > ${{ env.config }}
           cat ${{ env.config }} | jq .repositories
 
       # workflow_dispatch - optionally just one repo

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,7 +14,7 @@ on:
 
 # PR open and close use the same group, allowing only one at a time
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 # Variables

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -5,8 +5,8 @@ on:
     - cron: "0 11 * * *" # 3 AM PST = 11 AM UDT
   workflow_dispatch:
     inputs:
-      repository:
-        description: optional single org/repo to run against
+      repo:
+        description: org/repo override (optional)
         type: string
         required: false
 
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # PRs - dry run and a small number of repos
-      - name: Set dry run and repo list
+      - name: Config for pull requests
         if: github.event_name == 'pull_request'
         env:
           repos: '["bcgov/nr-renovate", "bcgov/quickstart-openshift"]'
@@ -36,14 +36,14 @@ jobs:
           cat ${{ env.config }} | jq .repositories
 
       # workflow_dispatch - optionally just one repo
-      - name: Set dry run and repo list
-        if: inputs.repository
+      - name: Config for manual workflows (optional)
+        if: inputs.repo
         run: |
-          cat <<< $(jq '. | .repositories = ["${{ inputs.repository }}"]' ${{ env.config }}) > ${{ env.config }}
+          cat <<< $(jq '. | .repositories = ["${{ inputs.repo }}"]' ${{ env.config }}) > ${{ env.config }}
           cat ${{ env.config }} | jq .repositories
 
       # Run Renovate
-      - name: Self-hosted Renovate
+      - name: Run Renovate
         uses: renovatebot/github-action@v39.0.1
         with:
           configurationFile: ${{ env.config }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,7 +12,7 @@ on:
         type: string
         required: false
 
-# PR open and close use the same group, allowing only one at a time
+# Cancel any other workflows (PR, cron or manual)
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -20,7 +20,7 @@ concurrency:
 # Variables
 env:
   config: renovate.json
-  pr_repos: '["bcgov/nr-renovate", "bcgov/quickstart-openshift"]'
+  pr_set: '["bcgov/nr-renovate", "bcgov/quickstart-openshift"]'
 
 jobs:
   Renovate:
@@ -34,14 +34,16 @@ jobs:
       - name: Config for pull requests
         if: github.event_name == 'pull_request'
         run: |
+          # Dry run and short repo list
           cat <<< $(jq '.+= {"dryRun": "full"}' ${{ env.config }}) > ${{ env.config }}
-          cat <<< $(jq '. | .repositories = ${{ env.pr_repos }}' ${{ env.config }}) > ${{ env.config }}
+          cat <<< $(jq '. | .repositories = ${{ env.pr_set }}' ${{ env.config }}) > ${{ env.config }}
           cat ${{ env.config }} | jq .repositories
 
       # workflow_dispatch - optionally just one repo
       - name: Config for manual workflows (optional)
         if: inputs.repo
         run: |
+          # Set target repo
           cat <<< $(jq '. | .repositories = ["${{ inputs.repo }}"]' ${{ env.config }}) > ${{ env.config }}
           cat ${{ env.config }} | jq .repositories
 


### PR DESCRIPTION
Limit Renovate runs to just one repository using workflow_dispatch.

![Screenshot_20230811_115747](https://github.com/bcgov/nr-renovate/assets/4391600/99fae325-7951-4a1b-893d-bbd389072d83)