### PR TITLE
feat: Exclude digest pin requirement for Docker Github Actions (#198)

### DIFF
--- a/rules-actions.json5
+++ b/rules-actions.json5
@@ -32,6 +32,7 @@
       "matchManagers": ["github-actions"],
       "matchPackageNames": [
         "/^actions\\//",
+        "/^docker\\//",
         "/^github\\//"
       ]
     },


### PR DESCRIPTION
All credit goes to @jujaga!  Changes have been pulled in from his [forked PR](https://github.com/bcgov/renovate-config/pull/198) to make our workflows happy.

---

<!-- Provide a general summary of your changes in the Title above -->

# Description

Docker is generally a trusted industry provider for container implementations and should be excluded from digest pinning.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

N/A

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
