### PR TITLE
feat: replace downstream copilot-upstream.md with upstream release notes

### DIFF
--- a/default.json
+++ b/default.json
@@ -54,12 +54,16 @@
   ],
   "regexManagers": [
     {
-      "description": "Keep .github/copilot-upstream.md updated from bcgov/copilot-instructions GitHub releases.",
+      "description": "Replace entire copilot-upstream.md with content from bcgov/copilot-instructions release notes.",
       "fileMatch": [
         "^\\.github/copilot-upstream\\.md$"
       ],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "bcgov/copilot-instructions"
+      "depNameTemplate": "bcgov/copilot-instructions",
+      "matchStrings": [
+        "(?<everything>[\\s\\S]*)"
+      ],
+      "replaceStringTemplate": "{{{releaseNotes}}}"
     }
   ]
 }


### PR DESCRIPTION
This PR updates `default.json` to add a `regexManagers` entry that ensures downstream repositories with a `.github/copilot-upstream.md` file will have that file fully replaced with the content from the latest release notes of `bcgov/copilot-instructions`.

**Details:**
- Targets `.github/copilot-upstream.md` in downstream repositories.
- On each new release of `bcgov/copilot-instructions`, Renovate will open a PR to replace the entire file with the release notes content.
- Only repositories that already have `.github/copilot-upstream.md` will be affected.

This change enables seamless, automated propagation of upstream Copilot instructions to all subscribed repositories.