### PR TITLE
Revert "fix(deps): Use Renovate regex negation syntax to exclude prereleases"

### DIFF
--- a/default.json
+++ b/default.json
@@ -48,7 +48,8 @@
     {
       "description": "Block prerelease updates globally (alpha, beta, rc, next, preview, dev, experimental)",
       "groupSlug": "block-prerelease-globally",
-      "matchCurrentVersion": "!/.*-(alpha|beta|rc|next|preview|dev|experimental).*/"
+      "enabled": false,
+      "matchCurrentVersion": ".*-(alpha|beta|rc|next|preview|dev|experimental).*"
     }
   ]
 }


### PR DESCRIPTION
Reverts bcgov/renovate-config#211

That PR is causing some strange behaviour, like PR https://github.com/bcgov/nr-oracle-service/pull/116.  It appears that everything not matching a pre-release label is being grouped together.