### PR TITLE
chore: run Renovate before 6am every weekday

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -46,6 +46,8 @@
   "onboarding": true,
   "platform": "github",
   "platformAutomerge": true,
+  "timezone": "America/Vancouver",
+  "schedule": ["before 6am every weekday"],
   "prConcurrentLimit": 2,
   "pinDigests": true,
   "recreateWhen": "never",


### PR DESCRIPTION

## Summary
Add a daily weekday schedule to batch Renovate activity before work hours. Keeps default rebase behavior (auto).

## Rationale
Reduce daytime noise without creating backlog or forcing manual updates. Maintainers get predictable daily updates, with PRs proactively kept mergeable.

## Changes
- timezone: America/Vancouver
- schedule: before 6am every weekday
- No changes to rebase logic (defaults to auto)
