### PR TITLE
docs: remove references to deleted CONTRIBUTING.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ That's it! Renovate will automatically keep your dependencies up to date and sec
 - Add custom rules after the `extends` line in your `renovate.json`. See the [Renovate docs](https://docs.renovatebot.com/configuration-options/).
 
 **Q: How do I get help?**
-- See [CONTRIBUTING.md](CONTRIBUTING.md) or open an issue.
+- Open an [issue](https://github.com/bcgov/renovate-config/issues) for questions or problems.
 
 ## Version Control
 
@@ -76,11 +76,11 @@ That's it! Renovate will automatically keep your dependencies up to date and sec
 | `renovate.json` | Entry point for downstream repos |
 | `default.json` | Main shared config |
 | `rules-*.json5` | Language-specific rules |
-| `CONTRIBUTING.md` | How to contribute and get help |
+| `.copilot-instructions.md` | AI assistant guidelines |
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. By participating, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+Open an [issue](https://github.com/bcgov/renovate-config/issues) to report problems or suggest improvements. By participating, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Security
 


### PR DESCRIPTION
## Documentation Cleanup

This PR removes references to the deleted  file from the README.

### Changes:
- Updated FAQ section to direct users to open issues instead of referencing CONTRIBUTING.md
- Updated Contributing section to provide direct guidance instead of referencing the deleted file
- Updated Files table to reference  instead of the deleted file

### Why:
- The  file was removed in a previous cleanup
- These references were causing confusion and broken links
- The new guidance is more direct and actionable

This is a simple documentation cleanup to ensure the README is accurate and helpful.