### PR TITLE
feat: improve v1 migration rules for downstream teams

### DIFF
--- a/default.json
+++ b/default.json
@@ -192,7 +192,6 @@
       "matchPackageNames": [
         "github>bcgov/renovate-config"
       ],
-      "matchCurrentVersion": "/^(main|unstable)$/",
       "allowedVersions": "v1",
       "enabled": true,
       "automerge": false,


### PR DESCRIPTION
Improve v1 migration rules to better target teams using main/unstable references and migrate them to stable v1 tag.