### PR TITLE
fix: improve renovate-config precision rules

### DIFF
--- a/default.json
+++ b/default.json
@@ -157,7 +157,25 @@
       "groupSlug": "python"
     },
     {
-      "description": "Prevent decimal precision changes for renovate-config: Teams must stay at the same decimal precision level (e.g., v1.0.0 stays as 3 decimals, v1.2 stays as 2 decimals). This prevents unexpected version format changes.",
+      "description": "Prevent decimal precision changes for renovate-config: Teams must stay at the same decimal precision level (e.g., v1.0.0 stays as 3 decimals, v1.2 stays as 2 decimals, v1 stays as 1 decimal). This prevents unexpected version format changes.",
+      "matchPackageNames": [
+        "github>bcgov/renovate-config"
+      ],
+      "matchCurrentVersion": "/^v?\\d+$/",
+      "allowedVersions": "/^v?\\d+$/",
+      "enabled": true
+    },
+    {
+      "description": "Prevent decimal precision changes for renovate-config: Teams must stay at the same decimal precision level for 2-decimal versions (e.g., v1.2 stays as 2 decimals). This prevents unexpected version format changes.",
+      "matchPackageNames": [
+        "github>bcgov/renovate-config"
+      ],
+      "matchCurrentVersion": "/^v?\\d+\\.\\d+$/",
+      "allowedVersions": "/^v?\\d+\\.\\d+$/",
+      "enabled": true
+    },
+    {
+      "description": "Prevent decimal precision changes for renovate-config: Teams must stay at the same decimal precision level for 3-decimal versions (e.g., v1.0.0 stays as 3 decimals). This prevents unexpected version format changes.",
       "matchPackageNames": [
         "github>bcgov/renovate-config"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Repository-specific Renovate config. Extends the shared bcgov/renovate-config preset. Downstream repos should reference this file for consistent update management.",
   "extends": [
-    "github>bcgov/renovate-config#v1.1"
+    "github>bcgov/renovate-config#v1"
   ]
 }


### PR DESCRIPTION
## Problem
Renovate incorrectly updated the config reference from v1 to v1.1, which violates the principle of maintaining the same number of version digits. This creates unexpected version format changes that can confuse teams.

## Solution
- Reverted renovate.json to use v1 instead of v1.1 to maintain single-digit version format
- Enhanced packageRules in default.json to prevent decimal precision changes for all version formats:
  - v1 stays as 1 decimal (e.g., v1, v2)
  - v1.2 stays as 2 decimals (e.g., v1.2, v2.3) 
  - v1.0.0 stays as 3 decimals (e.g., v1.0.0, v2.1.0)

## Testing
- Configuration validated successfully with renovate-config-validator
- All precision rules tested and working correctly

This prevents Renovate from changing version precision levels inappropriately while preserving existing team versioning choices.