### PR TITLE
feat: automated release workflow with simultaneous tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,14 @@ jobs:
           echo "PATCH=$PATCH" >> $GITHUB_ENV
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
+      - name: Validate version doesn't exist
+        run: |
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "ERROR: Release $VERSION already exists!"
+            exit 1
+          fi
+          echo "Version $VERSION is available for release"
+
       - name: Create version tags
         run: |
           echo "Creating tags for major: v$MAJOR, minor: v$MAJOR.$MINOR, patch: $VERSION"


### PR DESCRIPTION
## Overview
Creates a GitHub Actions workflow for automated release management with simultaneous tag creation to prevent Renovate timestamp confusion.

## Features
- **Manual trigger**: workflow_dispatch with version input (e.g., v1.1.0)
- **Triple tagging**: Creates v1, v1.1, and v1.1.0 tags simultaneously
- **Force push**: Updates existing major/minor tags with --force flag
- **Validation**: Prevents duplicate patch releases
- **Auto-generated notes**: Uses gh CLI with --generate-notes
- **Native tools**: Uses git + gh commands instead of external actions

## Problem Solved
Previously, manual tag creation order caused Renovate to prefer newer tags based on creation timestamps, leading to unwanted version updates (v1 → v1.1). This workflow ensures all related tags have identical timestamps.

## Usage
1. Go to Actions → Release workflow
2. Click 'Run workflow'
3. Enter version (e.g., v1.1.0)
4. Workflow creates all three tags and GitHub release

## Technical Details
- Creates tags: v1, v1.1, v1.1.0 (all with identical timestamps)
- Creates release: Release v1.1.0 attached to patch tag
- Validates version doesn't already exist
- Uses fetch-depth: 0 for full Git history access