### PR TITLE
feat: implement two-stream renovate-config versioning strategy

### DIFF
--- a/default.json
+++ b/default.json
@@ -173,25 +173,6 @@
       "matchCurrentVersion": "/^v?(\\d+)\\.\\d+(\\.\\d+)?$/",
       "allowedVersions": "/^v?\\d+\\.\\d+$/",
       "enabled": true
-    },
-    {
-      "description": "Update unversioned renovate-config references to v1: Target repositories using the unversioned reference and update them to use the stable v1 tag, while ignoring repositories already using specific version tags.",
-      "matchFileNames": [
-        "renovate.json"
-      ],
-      "matchPackageNames": [
-        "github>bcgov/renovate-config"
-      ],
-      "matchCurrentVersion": "!/^v\\d+\\.\\d+(\\.\\d+)?$/",
-      "allowedVersions": "v1",
-      "enabled": true,
-      "automerge": false,
-      "commitMessageAction": "Update",
-      "commitMessageTopic": "bcgov renovate-config",
-      "commitMessageExtra": "to v1",
-      "prCreation": "not-pending",
-      "recreateWhen": "never",
-      "prBody": "## Update Renovate Config to v1\n\nThis PR updates your Renovate configuration from the unversioned reference to the stable v1 tag.\n\n### What Changes:\n- `github>bcgov/renovate-config` → `github>bcgov/renovate-config#v1`\n\n### Benefits:\n- ✅ **Stable updates** - get tested releases, not development changes\n- ✅ **Automatic upgrades** - get new v1.x.x releases automatically\n- ✅ **No breaking changes** - won't get v2+ breaking changes\n- ✅ **Easy rollback** - can pin to specific version if needed\n\nThis change is recommended for production stability. The v1 version receives regular updates and bug fixes while maintaining backward compatibility."
     }
   ]
 }


### PR DESCRIPTION
## Two-Stream Versioning Strategy

This PR implements a clean two-stream approach for renovate-config updates, addressing the v1→v1.1 bug while providing teams with flexible update strategies.

### 🔄 Rolling Stream (Low Maintenance)
- **Users**: Teams using `github>bcgov/renovate-config#v1`, `#v2`, `#v3`
- **Updates**: v1 → v2 → v3 (major versions only)
- **Behavior**: Automatic feature updates, minimal maintenance
- **Pattern**: `/^v?(\\d+)$/` → `/^v?(\\d+)$/`

### 🛡️ Conservative Stream (High Control)
- **Users**: Teams using `github>bcgov/renovate-config#v1.1`, `#v1.2`, `#v2.1`
- **Updates**: v1.1 → v1.2 → v1.3 → v2.0 (minor versions, can cross major)
- **Behavior**: Granular control, can stay on specific minor versions
- **Pattern**: `/^v?(\\d+)\\.\\d+(\\.\\d+)?$/` → `/^v?\\d+\\.\\d+$/`

## Key Benefits

### ✅ Bug Fix
- **Eliminates v1→v1.1 updates**: v1 users only match rolling stream rule
- **Explicit version patterns**: No reliance on Renovate's major/minor classification
- **Higher precedence**: `matchDatasources` ensures rules override global automerge presets

### ✅ Simplified Configuration
- **2 rules instead of 3**: Removed temporary migration rule
- **Clear separation**: No overlapping regex patterns
- **Future-proof**: Automatically works for v2, v3, v4, etc.

### ✅ Team Flexibility
- **Rolling teams**: Get automatic major updates (v1→v2→v3)
- **Conservative teams**: Get granular minor updates (v1.1→v1.2→v2.0)
- **No cross-stream pollution**: Each stream stays within its intended behavior

## Technical Details

- Uses `allowedVersions` regex patterns instead of `matchUpdateTypes`
- Adds `matchDatasources: ["github-tags"]` for rule precedence
- Removes temporary unversioned migration rule
- Maintains automerge functionality for allowed updates

## Testing

This should eliminate the `renovate/bcgov-renovate-config-1.x` branches that were being created for v1→v1.1 updates.

Resolves the frustrating v1→v1.1 update issue while providing a sustainable long-term versioning strategy.
