### PR TITLE
fix(rules-javascript): add lodash and nodemailer grouping rules

### DIFF
--- a/rules-javascript.json5
+++ b/rules-javascript.json5
@@ -55,6 +55,18 @@
         "/reflect-metadata/"
       ]
     },
+    // Group lodash (frequent CVEs)
+    {
+      "description": "Group lodash",
+      "groupName": "lodash",
+      "matchPackageNames": ["/^lodash$/"]
+    },
+    // Group nodemailer (common SMTP vulnerabilities)
+    {
+      "description": "Group nodemailer",
+      "groupName": "nodemailer",
+      "matchPackageNames": ["/^nodemailer$/", "/^mailparser$/"]
+    },
     // Group @mui dependencies
     {
       "description": "Group @mui",


### PR DESCRIPTION
## Summary
Add grouping rules for lodash and nodemailer packages in JavaScript rules.

## Changes
- **lodash**: Grouped separately due to frequent CVEs (prototype pollution, code execution)
- **nodemailer**: Grouped with mailparser due to common SMTP vulnerabilities

## Rationale
These packages are frequent targets for security vulnerabilities. Grouping them:
- Isolates security-critical updates
- Makes PRs easier to review
- Ensures related dependencies update together