### PR TITLE
feat: add Python grouping rules and enforce ecosystem scoping

### DIFF
--- a/rules-javascript.json5
+++ b/rules-javascript.json5
@@ -17,36 +17,42 @@
     {
       "description": "Group vite",
       "groupName": "vite",
+      "matchManagers": ["npm", "yarn", "pnpm"],
       "matchPackageNames": ["/^vite$/", "/^@vitejs\\//"]
     },
     // Group linters
     {
       "description": "Group linters",
       "groupName": "linters",
+      "matchManagers": ["npm", "yarn", "pnpm"],
       "matchPackageNames": ["/eslint/", "/^@prettier\\//", "/^prettier-plugin-/"]
     },
     // Group @angular dependencies
     {
       "description": "Group @angular",
       "groupName": "angular",
+      "matchManagers": ["npm", "yarn", "pnpm"],
       "matchPackageNames": ["/^@angular\\//", "/^@angular-/"]
     },
     // Group aws-amplify dependencies
     {
       "description": "Group aws-amplify",
       "groupName": "aws-amplify",
+      "matchManagers": ["npm", "yarn", "pnpm"],
       "matchPackageNames": ["/^@aws-amplify\\//", "/^aws-amplify/"]
     },
     // Group @testing-library dependencies
     {
       "description": "Group @testing-library",
       "groupName": "testing-library",
+      "matchManagers": ["npm", "yarn", "pnpm"],
       "matchPackageNames": ["/^@testing-library\\//"]
     },
     // Group @nestjs dependencies
     {
       "description": "Group @nestjs",
       "groupName": "nestjs",
+      "matchManagers": ["npm", "yarn", "pnpm"],
       "matchPackageNames": [
         "/^@nestjs\\//",
         "/^@swc\\//",
@@ -59,24 +65,28 @@
     {
       "description": "Group lodash",
       "groupName": "lodash",
+      "matchManagers": ["npm", "yarn", "pnpm"],
       "matchPackageNames": ["/^lodash$/"]
     },
     // Group nodemailer (common SMTP vulnerabilities)
     {
       "description": "Group nodemailer",
       "groupName": "nodemailer",
+      "matchManagers": ["npm", "yarn", "pnpm"],
       "matchPackageNames": ["/^nodemailer$/", "/^mailparser$/"]
     },
     // Group @mui dependencies
     {
       "description": "Group @mui",
       "groupName": "mui",
+      "matchManagers": ["npm", "yarn", "pnpm"],
       "matchPackageNames": ["/^@mui\\//"]
     },
     // Group redux dependencies
     {
       "description": "Group redux",
       "groupName": "redux",
+      "matchManagers": ["npm", "yarn", "pnpm"],
       "matchPackageNames": [
         "/^@redux-devtools\\//",
         "/redux/",

--- a/rules-python.json5
+++ b/rules-python.json5
@@ -17,12 +17,14 @@
     {
       "description": "Group boto",
       "groupName": "boto",
+      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
       "matchPackageNames": ["/^boto3$/", "/^botocore$/"]
     },
     // Group all pytest-related dependencies for unified update PRs
     {
       "description": "Group pytest",
       "groupName": "pytest",
+      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
       "matchPackageNames": [
         "/^pytest$/",
         "/^pytest-/",
@@ -37,6 +39,7 @@
     {
       "description": "Group sqlalchemy",
       "groupName": "sqlalchemy",
+      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
       "matchPackageNames": [
         "/^sqlalchemy$/",
         "/^sqlmodel$/",
@@ -49,6 +52,7 @@
     {
       "description": "Group python linters",
       "groupName": "python linters",
+      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
       "matchPackageNames": [
         "/^ruff$/",
         "/^black$/",
@@ -64,6 +68,7 @@
     {
       "description": "Group pydantic",
       "groupName": "pydantic",
+      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
       "matchPackageNames": [
         "/^pydantic$/",
         "/^pydantic-core$/",
@@ -74,6 +79,7 @@
     {
       "description": "Group fastapi stack",
       "groupName": "fastapi stack",
+      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
       "matchPackageNames": [
         "/^fastapi$/",
         "/^starlette$/",
@@ -88,6 +94,7 @@
     {
       "description": "Group ai-ml",
       "groupName": "ai-ml",
+      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
       "matchPackageNames": [
         "/^huggingface-hub$/",
         "/^tokenizers$/",
@@ -102,6 +109,7 @@
     {
       "description": "Group data science",
       "groupName": "data science",
+      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
       "matchPackageNames": [
         "/^numpy$/",
         "/^pandas$/",
@@ -115,6 +123,7 @@
     {
       "description": "Group python tools",
       "groupName": "python tools",
+      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
       "matchPackageNames": [
         "/^uv$/",
         "/^setuptools$/",

--- a/rules-python.json5
+++ b/rules-python.json5
@@ -23,7 +23,15 @@
     {
       "description": "Group pytest",
       "groupName": "pytest",
-      "matchPackageNames": ["/^pytest$/", "/^pytest-/"]
+      "matchPackageNames": [
+        "/^pytest$/",
+        "/^pytest-/",
+        "/^coverage$/",
+        "/^tox$/",
+        "/^mock$/",
+        "/^factory-boy$/",
+        "/^freezegun$/"
+      ]
     },
     // Group SQLAlchemy and related tools for easier upgrades
     {
@@ -33,7 +41,87 @@
         "/^sqlalchemy$/",
         "/^sqlmodel$/",
         "/^sqlacodegen$/",
-        "/^mock-alchemy$/"
+        "/^mock-alchemy$/",
+        "/^alembic$/"
+      ]
+    },
+    // Group linters and formatters
+    {
+      "description": "Group python linters",
+      "groupName": "python linters",
+      "matchPackageNames": [
+        "/^ruff$/",
+        "/^black$/",
+        "/^isort$/",
+        "/^pylint$/",
+        "/^flake8$/",
+        "/^mypy$/",
+        "/^bandit$/",
+        "/^pre-commit$/"
+      ]
+    },
+    // Group pydantic and its core components
+    {
+      "description": "Group pydantic",
+      "groupName": "pydantic",
+      "matchPackageNames": [
+        "/^pydantic$/",
+        "/^pydantic-core$/",
+        "/^annotated-types$/"
+      ]
+    },
+    // Group FastAPI and related web stack components
+    {
+      "description": "Group fastapi stack",
+      "groupName": "fastapi stack",
+      "matchPackageNames": [
+        "/^fastapi$/",
+        "/^starlette$/",
+        "/^python-multipart$/",
+        "/^uvicorn$/",
+        "/^gunicorn$/",
+        "/^httpx$/",
+        "/^anyio$/"
+      ]
+    },
+    // Group AI and Machine Learning dependencies
+    {
+      "description": "Group ai-ml",
+      "groupName": "ai-ml",
+      "matchPackageNames": [
+        "/^huggingface-hub$/",
+        "/^tokenizers$/",
+        "/^hf-xet$/",
+        "/^onnxruntime$/",
+        "/^openai$/",
+        "/^langchain/",
+        "/^llama-index/"
+      ]
+    },
+    // Group core data science libraries
+    {
+      "description": "Group data science",
+      "groupName": "data science",
+      "matchPackageNames": [
+        "/^numpy$/",
+        "/^pandas$/",
+        "/^scipy$/",
+        "/^matplotlib$/",
+        "/^seaborn$/",
+        "/^scikit-learn$/"
+      ]
+    },
+    // Group python development tools
+    {
+      "description": "Group python tools",
+      "groupName": "python tools",
+      "matchPackageNames": [
+        "/^uv$/",
+        "/^setuptools$/",
+        "/^tomlkit$/",
+        "/^orjson$/",
+        "/^pip$/",
+        "/^pip-tools$/"
       ]
     },
     {


### PR DESCRIPTION
This PR adds comprehensive Python dependency grouping rules to `rules-python.json5` and enforces ecosystem scoping across both Python and JavaScript rules to prevent cross-language collisions.

### Key Changes
- **Comprehensive Python Grouping**: Added groups for Linters, Pydantic, FastAPI Stack, AI/ML, Data Science, and Python Tooling to reduce PR noise.
- **Expanded Test/ORM Groups**: Added common utilities like `coverage`, `tox`, `mock`, and `alembic` to existing pytest and sqlalchemy groups.
- **Ecosystem Scoping (Security Fix)**: Added `matchManagers` scoping to all language-specific rules in both `rules-python.json5` and `rules-javascript.json5`. This prevents generic package names (e.g., `mock`, `coverage`, `lodash`) from matching across different ecosystems.

### Performance Impact
- Reduces PR volume for Python projects by consolidating related stack updates.
- Eliminates potential 'identity crisis' issues where one language's rules might incorrectly capture another's dependencies.

Closes #351 (internal reference)