### PR TITLE
fix(python): expand matchManagers to include all relevant managers

### DIFF
--- a/rules-javascript.json5
+++ b/rules-javascript.json5
@@ -9,7 +9,8 @@
       "matchManagers": [
         "npm",
         "yarn",
-        "pnpm"
+        "pnpm",
+        "bun"
       ],
       "pinDigests": true
     },
@@ -17,42 +18,42 @@
     {
       "description": "Group vite",
       "groupName": "vite",
-      "matchManagers": ["npm", "yarn", "pnpm"],
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
       "matchPackageNames": ["/^vite$/", "/^@vitejs\\//"]
     },
     // Group linters
     {
       "description": "Group linters",
       "groupName": "linters",
-      "matchManagers": ["npm", "yarn", "pnpm"],
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
       "matchPackageNames": ["/eslint/", "/^@prettier\\//", "/^prettier-plugin-/"]
     },
     // Group @angular dependencies
     {
       "description": "Group @angular",
       "groupName": "angular",
-      "matchManagers": ["npm", "yarn", "pnpm"],
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
       "matchPackageNames": ["/^@angular\\//", "/^@angular-/"]
     },
     // Group aws-amplify dependencies
     {
       "description": "Group aws-amplify",
       "groupName": "aws-amplify",
-      "matchManagers": ["npm", "yarn", "pnpm"],
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
       "matchPackageNames": ["/^@aws-amplify\\//", "/^aws-amplify/"]
     },
     // Group @testing-library dependencies
     {
       "description": "Group @testing-library",
       "groupName": "testing-library",
-      "matchManagers": ["npm", "yarn", "pnpm"],
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
       "matchPackageNames": ["/^@testing-library\\//"]
     },
     // Group @nestjs dependencies
     {
       "description": "Group @nestjs",
       "groupName": "nestjs",
-      "matchManagers": ["npm", "yarn", "pnpm"],
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
       "matchPackageNames": [
         "/^@nestjs\\//",
         "/^@swc\\//",
@@ -65,28 +66,28 @@
     {
       "description": "Group lodash",
       "groupName": "lodash",
-      "matchManagers": ["npm", "yarn", "pnpm"],
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
       "matchPackageNames": ["/^lodash$/"]
     },
     // Group nodemailer (common SMTP vulnerabilities)
     {
       "description": "Group nodemailer",
       "groupName": "nodemailer",
-      "matchManagers": ["npm", "yarn", "pnpm"],
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
       "matchPackageNames": ["/^nodemailer$/", "/^mailparser$/"]
     },
     // Group @mui dependencies
     {
       "description": "Group @mui",
       "groupName": "mui",
-      "matchManagers": ["npm", "yarn", "pnpm"],
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
       "matchPackageNames": ["/^@mui\\//"]
     },
     // Group redux dependencies
     {
       "description": "Group redux",
       "groupName": "redux",
-      "matchManagers": ["npm", "yarn", "pnpm"],
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
       "matchPackageNames": [
         "/^@redux-devtools\\//",
         "/redux/",
@@ -99,7 +100,8 @@
       "matchManagers": [
         "npm",
         "yarn",
-        "pnpm"
+        "pnpm",
+        "bun"
       ],
       "matchUpdateTypes": [
         "minor",

--- a/rules-javascript.json5
+++ b/rules-javascript.json5
@@ -96,7 +96,7 @@
       ]
     },
     {
-      "description": "Group Node.js ecosystem: Combine npm, yarn, and pnpm updates into single PRs. JavaScript/TypeScript dependencies should be updated together to maintain compatibility.",
+      "description": "Group Node.js ecosystem: Combine updates from all JavaScript managers (npm, yarn, pnpm, bun) into single PRs. JavaScript/TypeScript dependencies should be updated together to maintain compatibility.",
       "matchManagers": [
         "npm",
         "yarn",

--- a/rules-python.json5
+++ b/rules-python.json5
@@ -6,10 +6,13 @@
     {
       "description": "Pin Python dependencies: Pin all digests/SHAs for supply chain security. This ensures reproducible builds and prevents dependency substitution attacks.",
       "matchManagers": [
-        "pip",
+        "pip_requirements",
+        "pip_setup",
         "pipenv",
         "poetry",
-        "uv"
+        "uv",
+        "pep621",
+        "pip-compile"
       ],
       "pinDigests": true
     },
@@ -17,14 +20,14 @@
     {
       "description": "Group boto",
       "groupName": "boto",
-      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
       "matchPackageNames": ["/^boto3$/", "/^botocore$/"]
     },
     // Group all pytest-related dependencies for unified update PRs
     {
       "description": "Group pytest",
       "groupName": "pytest",
-      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
       "matchPackageNames": [
         "/^pytest$/",
         "/^pytest-/",
@@ -39,7 +42,7 @@
     {
       "description": "Group sqlalchemy",
       "groupName": "sqlalchemy",
-      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
       "matchPackageNames": [
         "/^sqlalchemy$/",
         "/^sqlmodel$/",
@@ -52,7 +55,7 @@
     {
       "description": "Group python linters",
       "groupName": "python linters",
-      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
       "matchPackageNames": [
         "/^ruff$/",
         "/^black$/",
@@ -68,7 +71,7 @@
     {
       "description": "Group pydantic",
       "groupName": "pydantic",
-      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
       "matchPackageNames": [
         "/^pydantic$/",
         "/^pydantic-core$/",
@@ -79,7 +82,7 @@
     {
       "description": "Group fastapi stack",
       "groupName": "fastapi stack",
-      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
       "matchPackageNames": [
         "/^fastapi$/",
         "/^starlette$/",
@@ -94,7 +97,7 @@
     {
       "description": "Group ai-ml",
       "groupName": "ai-ml",
-      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
       "matchPackageNames": [
         "/^huggingface-hub$/",
         "/^tokenizers$/",
@@ -109,7 +112,7 @@
     {
       "description": "Group data science",
       "groupName": "data science",
-      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
       "matchPackageNames": [
         "/^numpy$/",
         "/^pandas$/",
@@ -123,7 +126,7 @@
     {
       "description": "Group python tools",
       "groupName": "python tools",
-      "matchManagers": ["pip", "pipenv", "poetry", "uv"],
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
       "matchPackageNames": [
         "/^uv$/",
         "/^setuptools$/",
@@ -136,10 +139,13 @@
     {
       "description": "Group Python ecosystem: Combine pip, pipenv, poetry, and uv updates into single PRs. Python dependencies should be updated together to maintain compatibility and avoid conflicts.",
       "matchManagers": [
-        "pip",
+        "pip_requirements",
+        "pip_setup",
         "pipenv",
         "poetry",
-        "uv"
+        "uv",
+        "pep621",
+        "pip-compile"
       ],
       "matchUpdateTypes": [
         "minor",

--- a/rules-python.json5
+++ b/rules-python.json5
@@ -137,7 +137,7 @@
       ]
     },
     {
-      "description": "Group Python ecosystem: Combine pip, pipenv, poetry, and uv updates into single PRs. Python dependencies should be updated together to maintain compatibility and avoid conflicts.",
+      "description": "Group Python ecosystem: Combine updates from all Python managers (pip_requirements, pip_setup, pipenv, poetry, uv, pep621, pip-compile) into single PRs to maintain compatibility.",
       "matchManagers": [
         "pip_requirements",
         "pip_setup",


### PR DESCRIPTION
This PR fixes the grouping logic for Python by expanding `matchManagers` to include `pip_requirements` and `pep621`, which are the actual manager names used by Renovate for `requirements.txt` and `pyproject.toml`.