### PR TITLE
docs(versioning): adopt SemVer-compatible Calendar Versioning standard

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -39,8 +39,8 @@ jobs:
           echo "🔧 Updating renovate.json to point to current PR branch for validation..."
           # Get current branch name (PR branch)
           CURRENT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          # Temporarily update renovate.json to point to current branch instead of v1
-          sed -i "s|github>bcgov/renovate-config#v1|github>bcgov/renovate-config#$CURRENT_BRANCH|" renovate.json
+          # Temporarily update renovate.json to point to current branch instead of the pinned version
+          sed -i "s|github>bcgov/renovate-config#[^\"']*|github>bcgov/renovate-config#$CURRENT_BRANCH|" renovate.json
           echo "✅ Updated renovate.json to reference branch: $CURRENT_BRANCH"
 
       - name: Schema validation
@@ -191,8 +191,8 @@ jobs:
           echo "📋 GITHUB_REF: $GITHUB_REF"
           echo "📋 Before sed - renovate.json content:"
           cat renovate.json
-          # Temporarily update renovate.json to point to current branch instead of v1
-          sed -i "s|github>bcgov/renovate-config#v1|github>bcgov/renovate-config#$CURRENT_BRANCH|" renovate.json
+          # Temporarily update renovate.json to point to current branch instead of the pinned version
+          sed -i "s|github>bcgov/renovate-config#[^\"']*|github>bcgov/renovate-config#$CURRENT_BRANCH|" renovate.json
           echo "📋 After sed - renovate.json content:"
           cat renovate.json
           echo "✅ Updated renovate.json to reference branch: $CURRENT_BRANCH"

--- a/README.md
+++ b/README.md
@@ -57,30 +57,25 @@ That's it! Renovate will automatically keep your dependencies up to date and sec
 
 ## Version Control
 
-**Use Versioned Releases:**
+**Use Versioned Releases (SemVer-Compatible Calendar Versioning):**
+```json
+"extends": ["github>bcgov/renovate-config#2026.4.0"]
 ```
-"extends": ["github>bcgov/renovate-config#2025.10"]
-```
-✅ Quarterly releases - tested, stable updates
-✅ Calendar versioning (YYYY.Q format) like Ubuntu releases
-✅ Minimal PR noise with predictable update cadence
+✅ **Quarterly releases** - thoroughly tested, stable updates.
+✅ **SemVer-Compatible CalVer** (`YYYY.M.Patch` format) ensures compatibility with automated tools like Renovate and Dependabot out of the box.
+✅ **No leading zeros in month segments** (e.g., use `.4` instead of `.04`).
+✅ **Always specify a third segment** (e.g., `.0` for the initial release) so standard SemVer parsers can compare versions correctly and trigger automatic downstream updates.
 
 **Testing Only (Not Recommended for Production):**
-```
+```json
 "extends": ["github>bcgov/renovate-config"]
 ```
-⚠️ Latest changes from main branch - may include breaking updates
-⚠️ Use only for internal testing and development projects
+⚠️ Latest changes from main branch - may include breaking updates.
+⚠️ Use only for internal testing and development projects.
 
-**Migration from Old Format:**
-```
-"extends": ["github>bcgov/renovate-config#v1.2.3"]  // Old three-digit format
-```
-🔄 **Auto-migration:** All teams using versioned configs (v1.x, v1.x.x, etc.) will automatically receive updates to the latest CalVer release (e.g., `2025.10`)
-
-🔄 **Simplified versioning:** No more patch-level complexity - just quarterly releases
-
-🔄 **Universal transition:** This applies to all existing versioned references, not just three-digit formats
+**Migration & Auto-Updates:**
+🔄 **Three-Segment Standard**: All releases are published as `YYYY.Month.Patch` (e.g., `2025.10.1`, `2026.4.0`).
+🔄 **Seamless Propagation**: By maintaining three-digit SemVer compatibility, Renovate will naturally detect newer releases and open automated PRs to update your repositories' pins.
 
 ## Files
 

--- a/README.md
+++ b/README.md
@@ -59,23 +59,27 @@ That's it! Renovate will automatically keep your dependencies up to date and sec
 
 **Use Versioned Releases (SemVer-Compatible Calendar Versioning):**
 ```json
-"extends": ["github>bcgov/renovate-config#2026.4.0"]
+{
+  "extends": ["github>bcgov/renovate-config#2026.4.0"]
+}
 ```
-✅ **Quarterly releases** - thoroughly tested, stable updates.
+✅ **Quarterly releases** (month segment reflects the release month) - thoroughly tested, stable updates.
 ✅ **SemVer-Compatible CalVer** (`YYYY.M.Patch` format) ensures compatibility with automated tools like Renovate and Dependabot out of the box.
 ✅ **No leading zeros in month segments** (e.g., use `.4` instead of `.04`).
 ✅ **Always specify a third segment** (e.g., `.0` for the initial release) so standard SemVer parsers can compare versions correctly and trigger automatic downstream updates.
 
 **Testing Only (Not Recommended for Production):**
 ```json
-"extends": ["github>bcgov/renovate-config"]
+{
+  "extends": ["github>bcgov/renovate-config"]
+}
 ```
 ⚠️ Latest changes from main branch - may include breaking updates.
 ⚠️ Use only for internal testing and development projects.
 
 **Migration & Auto-Updates:**
 🔄 **Three-Segment Standard**: All releases are published as `YYYY.Month.Patch` (e.g., `2025.10.1`, `2026.4.0`).
-🔄 **Seamless Propagation**: By maintaining three-digit SemVer compatibility, Renovate will naturally detect newer releases and open automated PRs to update your repositories' pins.
+🔄 **Seamless Propagation**: By maintaining three-segment SemVer compatibility, Renovate will naturally detect newer releases and open automated PRs to update your repositories' pins.
 
 ## Files
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Repository-specific Renovate config. Extends the shared bcgov/renovate-config preset. Downstream repos should reference this file for consistent update management.",
   "extends": [
-    "github>bcgov/renovate-config#2025.10.1"
+    "github>bcgov/renovate-config#2026.4.0"
   ]
 }


### PR DESCRIPTION
Transition Renovate config versioning from YYYY.MM to YYYY.M.Patch format. This solves the compatibility issue where standard SemVer parsers rejected the two-digit CalVer (2026.04) and failed to trigger automated downstream updates. Upstream releases will now be published as YYYY.M.Patch (e.g., 2026.4.0) to enable seamless out-of-the-box auto-updates.