### PR TITLE
feat(config): pin onboarding and automate unpinned force-migration

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,7 +8,7 @@
       "customType": "regex",
       "description": "Auto-upgrade and pin downstream extends references to bcgov/renovate-config",
       "matchStrings": [
-        "\"github>bcgov/renovate-config(:[a-zA-Z0-9._-]+)?#(?<currentValue>[^\"]+)\""
+        "\"github>bcgov/renovate-config#(?<currentValue>[^\"]+)\""
       ],
       "depNameTemplate": "bcgov/renovate-config",
       "datasourceTemplate": "github-tags",
@@ -51,10 +51,10 @@
     ":rebaseStalePrs",
     ":semanticCommits",
     ":semanticCommitScope(deps)",
-    "github>bcgov/renovate-config:rules-infra.json5#2026.5.24",
-    "github>bcgov/renovate-config:rules-java.json5#2026.5.24",
-    "github>bcgov/renovate-config:rules-javascript.json5#2026.5.24",
-    "github>bcgov/renovate-config:rules-python.json5#2026.5.24"
+    "github>bcgov/renovate-config:rules-infra.json5",
+    "github>bcgov/renovate-config:rules-java.json5",
+    "github>bcgov/renovate-config:rules-javascript.json5",
+    "github>bcgov/renovate-config:rules-python.json5"
   ],
   "forkProcessing": "enabled",
   "ignorePresets": [

--- a/default.json
+++ b/default.json
@@ -8,7 +8,7 @@
       "customType": "regex",
       "description": "Auto-upgrade and pin downstream extends references to bcgov/renovate-config",
       "matchStrings": [
-        "\"github>bcgov/renovate-config#(?<currentValue>[^\"]+)\""
+        "\"github>bcgov/renovate-config(:[a-zA-Z0-9._-]+)?#(?<currentValue>[^\"]+)\""
       ],
       "depNameTemplate": "bcgov/renovate-config",
       "datasourceTemplate": "github-tags",
@@ -28,6 +28,7 @@
       "depNameTemplate": "bcgov/renovate-config",
       "datasourceTemplate": "github-tags",
       "currentValueTemplate": "0.0.0",
+      "autoReplaceStringTemplate": "\"github>bcgov/renovate-config#{{newValue}}\"",
       "extractVersionTemplate": "^(?<version>.*)$",
       "managerFilePatterns": [
         "/(^|/)renovate\\.json$/",
@@ -50,10 +51,10 @@
     ":rebaseStalePrs",
     ":semanticCommits",
     ":semanticCommitScope(deps)",
-    "github>bcgov/renovate-config:rules-infra.json5",
-    "github>bcgov/renovate-config:rules-java.json5",
-    "github>bcgov/renovate-config:rules-javascript.json5",
-    "github>bcgov/renovate-config:rules-python.json5"
+    "github>bcgov/renovate-config:rules-infra.json5#2026.5.24",
+    "github>bcgov/renovate-config:rules-java.json5#2026.5.24",
+    "github>bcgov/renovate-config:rules-javascript.json5#2026.5.24",
+    "github>bcgov/renovate-config:rules-python.json5#2026.5.24"
   ],
   "forkProcessing": "enabled",
   "ignorePresets": [

--- a/default.json
+++ b/default.json
@@ -8,10 +8,26 @@
       "customType": "regex",
       "description": "Auto-upgrade and pin downstream extends references to bcgov/renovate-config",
       "matchStrings": [
-        "\"github>bcgov/renovate-config(#(?<currentValue>[^\"]+))?\""
+        "\"github>bcgov/renovate-config#(?<currentValue>[^\"]+)\""
       ],
       "depNameTemplate": "bcgov/renovate-config",
       "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^(?<version>.*)$",
+      "managerFilePatterns": [
+        "/(^|/)renovate\\.json$/",
+        "/(^|/)renovate\\.json5$/",
+        "/(^|/)default\\.json$/"
+      ]
+    },
+    {
+      "customType": "regex",
+      "description": "Force-migrate unpinned downstream extends references to the latest release",
+      "matchStrings": [
+        "\"github>bcgov/renovate-config\""
+      ],
+      "depNameTemplate": "bcgov/renovate-config",
+      "datasourceTemplate": "github-tags",
+      "currentValueTemplate": "0.0.0",
       "extractVersionTemplate": "^(?<version>.*)$",
       "managerFilePatterns": [
         "/(^|/)renovate\\.json$/",
@@ -49,7 +65,7 @@
   "configWarningReuseIssue": true,
   "onboardingConfig": {
     "extends": [
-      "github>bcgov/renovate-config"
+      "github>bcgov/renovate-config#2026.5.24"
     ]
   },
   "platform": "github",
@@ -72,12 +88,6 @@
       "description": "Block prerelease updates globally: Prevent updates to alpha, beta, rc, next, preview, dev, experimental versions across all package managers. These are unstable and should be avoided in production.",
       "matchCurrentVersion": "/.*-(alpha|beta|rc|next|preview|dev|experimental).*/",
       "matchManagers": []
-    },
-    {
-      "description": "Renovate-config updates",
-      "matchPackageNames": [
-        "github>bcgov/renovate-config"
-      ]
     }
   ]
 }


### PR DESCRIPTION
## Description

This PR fixes the Renovate onboarding configuration and automates the migration of unpinned downstream repositories to versioned releases:

1. **Pinned Onboarding Config:** Hardens `onboardingConfig.extends` in `default.json` to use the stable release `#2026.5.24`.
2. **Onboarding Pin Automation:** Adds `default.json` to the file patterns of the primary regex manager, ensuring Renovate automatically bumps the onboarding pin inside `default.json` with every new tag release.
3. **Self-Healing Force-Migration:** Adds a new custom regex manager with a `0.0.0` `currentValueTemplate` trick to target downstream repositories using unpinned `main` configs and automatically hand them a PR to migrate to the latest versioned release.
4. **Code Purge & Cleanups:** Deletes an orphan, empty package rule at the bottom of `default.json` and simplifies the main regex manager to require explicit version pins.

Closes #368