### PR TITLE
feat(npm): block legacy peer dependencies globally

### DIFF
--- a/default.json
+++ b/default.json
@@ -73,6 +73,8 @@
   "platformAutomerge": true,
   "recreateWhen": "conflicted",
   "timezone": "America/Vancouver",
+  "npmrc": "legacy-peer-deps=false\n",
+  "npmrcMerge": true,
   "schedule": [
     "before 6am every weekday"
   ],


### PR DESCRIPTION
## Summary

This pull request enforces strict peer dependency resolution globally across the BC Gov Renovate presets. It blocks the usage of `legacy-peer-deps` during Renovate's lockfile updates by setting `"npmrc": "legacy-peer-deps=false\n"` and `"npmrcMerge": true` in `default.json`.

## Changes

- Added `"npmrc": "legacy-peer-deps=false\n"` to `default.json` to enforce strict peer dependency validation.
- Added `"npmrcMerge": true` to `default.json` to safely merge this requirement with repository-specific `.npmrc` files (e.g., registry, authentication, or scoped settings).

Closes bcgov/copilot-instructions#107
