### PR TITLE
fix(config): support optional v prefix in downstream references and tags

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,13 +8,13 @@
       "customType": "regex",
       "description": "Auto-upgrade and pin downstream extends references to bcgov/renovate-config",
       "matchStrings": [
-        "\"github>bcgov/renovate-config(#(?<currentValue>[^\"]+))?\""
+        "\"github>bcgov/renovate-config(#v?(?<currentValue>[^\"]+))?\""
       ],
       "depNameTemplate": "bcgov/renovate-config",
       "datasourceTemplate": "github-tags",
       "currentValueTemplate": "{{#if currentValue}}{{{currentValue}}}{{else}}0.0.0{{/if}}",
       "autoReplaceStringTemplate": "\"github>bcgov/renovate-config#{{{newValue}}}\"",
-      "extractVersionTemplate": "^(?<version>.*)$",
+      "extractVersionTemplate": "^v?(?<version>.*)$",
       "managerFilePatterns": [
         "/(^|/)renovate\\.json$/",
         "/(^|/)renovate\\.json5$/",


### PR DESCRIPTION
# Description

Support optional v prefix in downstream references and tags to permit clean upgrade to CalVer versions.

## Type of change

- [x] Bug fix
- [ ] New feature  
- [ ] Documentation update
- [x] Configuration change

## Checklist

- [x] Self-reviewed changes
- [x] Updated documentation if needed
- [x] No breaking changes to downstream users

Closes #374
