### PR TITLE
fix(config): allow unlimited major increments for renovate-config

### DIFF
--- a/default.json
+++ b/default.json
@@ -65,6 +65,13 @@
   "prConcurrentLimit": 2,
   "packageRules": [
     {
+      "description": "Allow unlimited major version upgrades for bcgov/renovate-config to support CalVer transitions",
+      "matchPackageNames": [
+        "bcgov/renovate-config"
+      ],
+      "maxMajorIncrement": 0
+    },
+    {
       "description": "Lock file maintenance: no minimumReleaseAge check (doesn't upgrade versions)",
       "matchUpdateTypes": [
         "lockFileMaintenance"


### PR DESCRIPTION
# Description

Allow unlimited major version upgrades for `bcgov/renovate-config` to support the transition to Calendar Versioning (CalVer) without hitting Renovate's `maxMajorIncrement` safeguard.

## Type of change

- [x] Bug fix
- [ ] New feature  
- [ ] Documentation update
- [x] Configuration change

## Checklist

- [x] Self-reviewed changes
- [x] Updated documentation if needed
- [x] No breaking changes to downstream users

Closes #376
