### PR TITLE
feat(javascript): add react-jsonschema-form dependency grouping

### DIFF
--- a/rules-javascript.json5
+++ b/rules-javascript.json5
@@ -83,6 +83,13 @@
       "matchManagers": ["npm", "yarn", "pnpm", "bun"],
       "matchPackageNames": ["/^@mui\\//"]
     },
+    // Group react-jsonschema-form (@rjsf) dependencies
+    {
+      "description": "Group react-jsonschema-form (@rjsf) dependencies to ensure core, utils, validator, and theme packages are updated together.",
+      "groupName": "react-jsonschema-form",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": ["/^@rjsf\\//"]
+    },
     // Group redux dependencies
     {
       "description": "Group redux",


### PR DESCRIPTION
Group all @rjsf/ scoped packages together to prevent peer dependency mismatches and build crashes across downstream JavaScript/TypeScript repositories.