### PR TITLE
feat(config): bypass stability wait for bcgov/renovate-config

### DIFF
--- a/default.json
+++ b/default.json
@@ -65,11 +65,12 @@
   "prConcurrentLimit": 2,
   "packageRules": [
     {
-      "description": "Allow unlimited major version upgrades for bcgov/renovate-config to support CalVer transitions",
+      "description": "Allow unlimited major version upgrades and bypass stability wait for bcgov/renovate-config to support CalVer transitions and critical config updates",
       "matchPackageNames": [
         "bcgov/renovate-config"
       ],
-      "maxMajorIncrement": 0
+      "maxMajorIncrement": 0,
+      "minimumReleaseAge": null
     },
     {
       "description": "Lock file maintenance: no minimumReleaseAge check (doesn't upgrade versions)",

--- a/default.json
+++ b/default.json
@@ -65,7 +65,7 @@
   "prConcurrentLimit": 2,
   "packageRules": [
     {
-      "description": "Allow unlimited major version upgrades and bypass stability wait for bcgov/renovate-config to support CalVer transitions and critical config updates",
+      "description": "Bypass stability wait and allow unlimited major version upgrades for bcgov/renovate-config to support CalVer transitions (where maxMajorIncrement: 0 disables the default increment limit)",
       "matchPackageNames": [
         "bcgov/renovate-config"
       ],


### PR DESCRIPTION
Bypass the 7-day stability wait period (minimumReleaseAge: null) specifically for updates to bcgov/renovate-config to ensure critical Renovate updates and hotfixes roll out downstream instantly without delay.