### PR TITLE
feat(js): block typescript 7.0 upgrades

### DIFF
--- a/rules-javascript.json5
+++ b/rules-javascript.json5
@@ -116,6 +116,12 @@
       ],
       "groupName": "node dependencies",
       "groupSlug": "node"
+    },
+    {
+      "description": "Block TypeScript 7.0.x upgrades due to linter/tooling incompatibility, while allowing versions < 7.0.0 or >= 7.1.0.",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "< 7.0.0 || >= 7.1.0"
     }
     // Add additional rules below as needed
   ]


### PR DESCRIPTION
### Summary
This PR adds a package rule to block TypeScript 7.0.x upgrades while permitting versions `< 7.0.0` or `>= 7.1.0`.

### Context & Rationale
TypeScript 7.0 is a native port to Go. Due to the compiler rewrite, it was released without a stable programmatic API, breaking ecosystem tooling such as `typescript-eslint`.
* **Permanent 7.0.x incompatibility:** A stable programmatic API is not planned for any patch releases (`7.0.1`, `7.0.2`, etc.). Microsoft has scheduled the restored programmatic API to ship with **TypeScript 7.1**.
* **Semver Range Protection:** The configured rule (`< 7.0.0 || >= 7.1.0`) successfully blocks the entire `7.0.x` release line while allowing a clean upgrade path once `7.1.0` is released.

### Alternative Workaround
If downstream projects need to run TypeScript 7.0 compilation while keeping ESLint functioning, Microsoft recommends using npm aliases to run the `@typescript/typescript6` compatibility package:
```bash
npm install -D typescript@npm:@typescript/typescript6
```
