### PR TITLE
chore(config): schedule 2am-8am, freeze daytime auto updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ These settings in the shared config affect security posture:
 | `:enableVulnerabilityAlerts` | Enabled | Renovate creates PRs in response to GitHub vulnerability alerts |
 | `minimumReleaseAge` | 7 days | Avoids adopting newly published (potentially compromised) packages immediately |
 | `prConcurrentLimit` | 5 | Limits open PRs to reduce noise while maintaining coverage |
-| `schedule` | Between 3am and 9am weekdays | Updates arrive during low-traffic hours |
+| `schedule` | Between 2am and 8am weekdays | Updates arrive during low-traffic hours |
+| `rebaseWhen` | `behind-base-branch` | Automatically rebases open PRs when default branch updates |
 | `automerge` | true | Safe updates merge automatically |
 | Prerelease blocking | Enabled | `-alpha`, `-beta`, `-rc`, etc. are never merged |
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ These settings in the shared config affect security posture:
 | `:enableVulnerabilityAlerts` | Enabled | Renovate creates PRs in response to GitHub vulnerability alerts |
 | `minimumReleaseAge` | 7 days | Avoids adopting newly published (potentially compromised) packages immediately |
 | `prConcurrentLimit` | 2 | Limits open PRs to reduce noise while maintaining coverage |
-| `schedule` | Before 6am weekdays | Updates arrive during low-traffic hours |
+| `schedule` | Before 3am weekdays | Updates arrive during low-traffic hours |
 | `automerge` | true | Safe updates merge automatically |
 | Prerelease blocking | Enabled | `-alpha`, `-beta`, `-rc`, etc. are never merged |
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ These settings in the shared config affect security posture:
 |---------|-------|---------|
 | `:enableVulnerabilityAlerts` | Enabled | Renovate creates PRs in response to GitHub vulnerability alerts |
 | `minimumReleaseAge` | 7 days | Avoids adopting newly published (potentially compromised) packages immediately |
-| `prConcurrentLimit` | 2 | Limits open PRs to reduce noise while maintaining coverage |
+| `prConcurrentLimit` | 5 | Limits open PRs to reduce noise while maintaining coverage |
 | `schedule` | Before 3am weekdays | Updates arrive during low-traffic hours |
 | `automerge` | true | Safe updates merge automatically |
 | Prerelease blocking | Enabled | `-alpha`, `-beta`, `-rc`, etc. are never merged |

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ These settings in the shared config affect security posture:
 | `:enableVulnerabilityAlerts` | Enabled | Renovate creates PRs in response to GitHub vulnerability alerts |
 | `minimumReleaseAge` | 7 days | Avoids adopting newly published (potentially compromised) packages immediately |
 | `prConcurrentLimit` | 5 | Limits open PRs to reduce noise while maintaining coverage |
-| `schedule` | Before 3am weekdays | Updates arrive during low-traffic hours |
+| `schedule` | Between 3am and 9am weekdays | Updates arrive during low-traffic hours |
 | `automerge` | true | Safe updates merge automatically |
 | Prerelease blocking | Enabled | `-alpha`, `-beta`, `-rc`, etc. are never merged |
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ These settings in the shared config affect security posture:
 | `prConcurrentLimit` | 5 | Limits open PRs to reduce noise while maintaining coverage |
 | `schedule` | Between 2am and 8am weekdays | Updates arrive during low-traffic hours |
 | `rebaseWhen` | `behind-base-branch` | Automatically rebases open PRs when default branch updates |
+| `updateNotScheduled` | `false` | Disables auto-updating/rebasing of PRs outside schedule window to prevent API throttling |
 | `automerge` | true | Safe updates merge automatically |
 | Prerelease blocking | Enabled | `-alpha`, `-beta`, `-rc`, etc. are never merged |
 

--- a/default.json
+++ b/default.json
@@ -62,7 +62,7 @@
   "schedule": [
     "before 3am every weekday"
   ],
-  "prConcurrentLimit": 2,
+  "prConcurrentLimit": 5,
   "packageRules": [
     {
       "description": "Bypass stability wait and allow unlimited major version upgrades for bcgov/renovate-config to support CalVer transitions (where maxMajorIncrement: 0 disables the default increment limit)",

--- a/default.json
+++ b/default.json
@@ -60,7 +60,7 @@
   "recreateWhen": "conflicted",
   "timezone": "America/Vancouver",
   "schedule": [
-    "before 3am every weekday"
+    "after 3am and before 9am every weekday"
   ],
   "prConcurrentLimit": 5,
   "packageRules": [

--- a/default.json
+++ b/default.json
@@ -60,8 +60,9 @@
   "recreateWhen": "conflicted",
   "timezone": "America/Vancouver",
   "schedule": [
-    "after 3am and before 9am every weekday"
+    "after 2am and before 8am every weekday"
   ],
+  "rebaseWhen": "behind-base-branch",
   "prConcurrentLimit": 5,
   "packageRules": [
     {

--- a/default.json
+++ b/default.json
@@ -63,6 +63,7 @@
     "after 2am and before 8am every weekday"
   ],
   "rebaseWhen": "behind-base-branch",
+  "updateNotScheduled": false,
   "prConcurrentLimit": 5,
   "packageRules": [
     {

--- a/default.json
+++ b/default.json
@@ -60,7 +60,7 @@
   "recreateWhen": "conflicted",
   "timezone": "America/Vancouver",
   "schedule": [
-    "before 6am every weekday"
+    "before 3am every weekday"
   ],
   "prConcurrentLimit": 2,
   "packageRules": [


### PR DESCRIPTION
This PR updates the shared Renovate configuration to run earlier, freeze auto-updating/rebasing of PRs during work hours (preventing GitHub API throttling), and rebase open PRs automatically when the default branch updates (within the scheduled window).

### Changes
* **Schedule Shift**: Changed Renovate schedule to `after 2am and before 8am every weekday` (previously `before 6am`) to give Renovate a 6-hour head start before 9 AM to process upgrades and automerges.
* **Continuous Rebasing (In-Window)**: Set `rebaseWhen` to `behind-base-branch` to ensure open PRs are kept fully up to date with the default branch when changes occur.
* **Daytime Freezing**: Set `updateNotScheduled` to `false`. This completely freezes Renovate auto-updating/rebasing during standard work hours (outside the 2-8 AM window), protecting your repository from GitHub API throttling and CI pipeline congestion. You can still trigger manual updates via PR checkboxes.
* **PR Concurrency Limit**: Increased `prConcurrentLimit` from `2` to `5` to prevent failing/manual-review PRs from stalling all other updates.
* **Documentation**: Updated the settings table in `README.md` to match these changes.