### PR TITLE
feat(config): prioritize and rate-limit security updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -42,6 +42,15 @@
     "github>bcgov/renovate-config:rules-javascript.json5",
     "github>bcgov/renovate-config:rules-python.json5"
   ],
+  "vulnerabilityAlerts": {
+    "description": "Bypass schedule and concurrency limit for vulnerability PRs",
+    "dependencyDashboardApproval": false,
+    "minimumReleaseAge": null,
+    "schedule": [
+      "at any time"
+    ],
+    "prConcurrentLimit": 0
+  },
   "forkProcessing": "enabled",
   "ignorePresets": [
     ":ignoreModulesAndTests"

--- a/default.json
+++ b/default.json
@@ -43,13 +43,14 @@
     "github>bcgov/renovate-config:rules-python.json5"
   ],
   "vulnerabilityAlerts": {
-    "description": "Bypass schedule and concurrency limit for vulnerability PRs",
+    "description": "Prioritize security vulnerability resolution PRs",
     "dependencyDashboardApproval": false,
-    "minimumReleaseAge": null,
+    "minimumReleaseAge": "3 days",
     "schedule": [
       "at any time"
     ],
-    "prConcurrentLimit": 0
+    "prConcurrentLimit": 3,
+    "prHourlyLimit": 1
   },
   "forkProcessing": "enabled",
   "ignorePresets": [


### PR DESCRIPTION
Configure Renovate to ignore schedule and concurrency limits for security updates/vulnerability alerts.

This adds a `vulnerabilityAlerts` configuration block to the default configuration which overrides constraints for security-related updates:

- Set `schedule` to `["at any time"]` (bypass global daily schedule)
- Set `prConcurrentLimit` to `3` (limits concurrent PR board clutter)
- Set `prHourlyLimit` to `1` (gradual rate-limited security PR rollout)
- Set `dependencyDashboardApproval` to `false`
- Set `minimumReleaseAge` to `"3 days"` (npm rug-pull safety window)

Closes #389

Note: overhauled to follow the recommendation of @jujaga.  Thanks!  :smile: 