### PR TITLE
fix: use main branch config for renovate to update itself

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,13 @@
   "description": "Repository-specific Renovate config. Extends the shared bcgov/renovate-config preset. Downstream repos should reference this file for consistent update management.",
   "extends": [
     "github>bcgov/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "bcgov/renovate-config"
+      ],
+      "enabled": false
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   ],
   "packageRules": [
     {
+      "description": "Disable auto-updates for this repository's own preset to ensure it always tests the main branch instead of pinning to past releases.",
       "matchPackageNames": [
         "bcgov/renovate-config"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Repository-specific Renovate config. Extends the shared bcgov/renovate-config preset. Downstream repos should reference this file for consistent update management.",
   "extends": [
-    "github>bcgov/renovate-config#2026.7.0"
+    "github>bcgov/renovate-config"
   ]
 }


### PR DESCRIPTION
The repository's own `renovate.json` was hardcoded to extend `github>bcgov/renovate-config#2026.7.0`. Because that tag still references the old `rules-infra.json5` preset, Renovate was trying to load that nested preset from the default branch (where it was recently deleted), causing a 404 error and blocking updates.

Removing the hardcoded tag allows the repository to test its own latest configuration from the default branch.

Additionally, a `packageRule` has been added to explicitly disable updates for `bcgov/renovate-config` within this repository, preventing Renovate from automatically pinning the preset back to the latest released tag. This ensures the config repository always tests `main` without fighting its own bot.
