### PR TITLE
chore(config): restore legacy json5 presets with deprecation warnings

### DIFF
--- a/rules-infra.json5
+++ b/rules-infra.json5
@@ -1,0 +1,68 @@
+// WARNING: This file is deprecated. It has been consolidated into default.json.
+// It is preserved here strictly for legacy repositories pinned to older config releases (like v2026.7.0).
+// DO NOT revise or maintain this file. Any rule updates should be made directly in default.json.
+//
+// Renovate packageRules for GitHub Actions dependencies.
+// This file is intended to be referenced by downstream repositories for consistent update grouping.
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Group infrastructure providers: Combine Terraform, Docker, Kubernetes, Helm, and Docker Compose updates into single PRs. Infrastructure changes should be reviewed together for consistency.",
+      "matchManagers": [
+        "terraform",
+        "dockerfile",
+        "kubernetes",
+        "helmv3",
+        "docker-compose"
+      ],
+      "groupName": "infrastructure updates",
+      "groupSlug": "infra"
+    },
+    {
+      "description": "Group non-major updates for GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest"
+      ],
+      "groupName": "github actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "Keep major GitHub Action updates separate",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": null
+    },
+    {
+      "description": "Database images: Block major updates (require migration/backup-restore), allow patch and minor updates",
+      "matchPackageNames": [
+        "/^postgres$/",
+        "/^mysql$/",
+        "/^mariadb$/",
+        "/^mongo$/",
+        "/^mongodb$/",
+        "/^redis$/"
+      ],
+      "matchManagers": [
+        "dockerfile",
+        "docker-compose",
+        "kubernetes"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    }
+  ]
+}

--- a/rules-java.json5
+++ b/rules-java.json5
@@ -1,0 +1,39 @@
+// WARNING: This file is deprecated. It has been consolidated into default.json.
+// It is preserved here strictly for legacy repositories pinned to older config releases (like v2026.7.0).
+// DO NOT revise or maintain this file. Any rule updates should be made directly in default.json.
+//
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  // Group Java dependencies for unified update PRs and easier management
+  "packageRules": [
+    // Pin Java dependencies for security
+    {
+      "description": "Pin Java dependencies: Pin all digests/SHAs for supply chain security. This ensures reproducible builds and prevents dependency substitution attacks.",
+      "matchManagers": [
+        "maven",
+        "gradle"
+      ],
+      "pinDigests": true
+    },
+    {
+      "description": "Group Java ecosystem: Combine Maven and Gradle updates into single PRs. Java dependencies should be updated together to maintain compatibility and avoid version conflicts.",
+      "matchManagers": [
+        "maven",
+        "gradle"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "java dependencies",
+      "groupSlug": "java"
+    },
+    // Example: Group all springframework dependencies
+    {
+      "description": "Group springframework",
+      "groupName": "springframework",
+      "matchPackageNames": ["/^org\\.springframework/", "/^spring-/"]
+    }
+    // Add more grouping rules as needed for your Java ecosystem
+  ]
+}

--- a/rules-javascript.json5
+++ b/rules-javascript.json5
@@ -1,0 +1,136 @@
+// WARNING: This file is deprecated. It has been consolidated into default.json.
+// It is preserved here strictly for legacy repositories pinned to older config releases (like v2026.7.0).
+// DO NOT revise or maintain this file. Any rule updates should be made directly in default.json.
+//
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  // Renovate packageRules for JavaScript/TypeScript dependencies.
+  // This file is intended to be referenced by downstream repositories for consistent update grouping and digest handling.
+  "packageRules": [
+    // Pin JavaScript/TypeScript dependencies for security
+    {
+      "description": "Pin JavaScript/TypeScript dependencies: Pin all digests/SHAs for supply chain security. This ensures reproducible builds and prevents dependency substitution attacks.",
+      "matchManagers": [
+        "npm",
+        "yarn",
+        "pnpm",
+        "bun"
+      ],
+      "pinDigests": true
+    },
+    {
+      "description": "Group Node.js ecosystem: Combine updates from all JavaScript managers (npm, yarn, pnpm, bun) into single PRs. JavaScript/TypeScript dependencies should be updated together to maintain compatibility.",
+      "matchManagers": [
+        "npm",
+        "yarn",
+        "pnpm",
+        "bun"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "node dependencies",
+      "groupSlug": "node"
+    },
+    // Group vite dependencies
+    {
+      "description": "Group vite",
+      "groupName": "vite",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": ["/^vite$/", "/^@vitejs\\//"]
+    },
+    // Group linters
+    {
+      "description": "Group linters",
+      "groupName": "linters",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": ["/eslint/", "/^@prettier\\//", "/^prettier-plugin-/"]
+    },
+    // Group @angular dependencies
+    {
+      "description": "Group @angular",
+      "groupName": "angular",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": ["/^@angular\\//", "/^@angular-/"]
+    },
+    // Group aws-amplify dependencies
+    {
+      "description": "Group aws-amplify",
+      "groupName": "aws-amplify",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": ["/^@aws-amplify\\//", "/^aws-amplify/"]
+    },
+    // Group @testing-library dependencies
+    {
+      "description": "Group @testing-library",
+      "groupName": "testing-library",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": ["/^@testing-library\\//"]
+    },
+    // Group @nestjs dependencies
+    {
+      "description": "Group @nestjs",
+      "groupName": "nestjs",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": [
+        "/^@nestjs\\//",
+        "/^@swc\\//",
+        "/nestjs-/",
+        "/nest-winston/",
+        "/reflect-metadata/"
+      ]
+    },
+    // Group lodash (frequent CVEs)
+    {
+      "description": "Group lodash",
+      "groupName": "lodash",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": ["/^lodash$/"]
+    },
+    // Group nodemailer (common SMTP vulnerabilities)
+    {
+      "description": "Group nodemailer",
+      "groupName": "nodemailer",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": ["/^nodemailer$/", "/^mailparser$/"]
+    },
+    // Group @mui dependencies
+    {
+      "description": "Group @mui",
+      "groupName": "mui",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": ["/^@mui\\//"]
+    },
+    // Group react-jsonschema-form (@rjsf) dependencies
+    {
+      "description": "Group react-jsonschema-form (@rjsf) dependencies to ensure core, utils, validator, and theme packages are updated together.",
+      "groupName": "react-jsonschema-form",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": ["/^@rjsf\\//"]
+    },
+    // Group redux dependencies
+    {
+      "description": "Group redux",
+      "groupName": "redux",
+      "matchManagers": ["npm", "yarn", "pnpm", "bun"],
+      "matchPackageNames": [
+        "/^@redux-devtools\\//",
+        "/redux/",
+        "/react-redux/",
+        "/redux-thunk/"
+      ]
+    },
+    {
+      "description": "Group Playwright packages, docker images, and GitHub Actions into a single PR",
+      "matchPackageNames": [
+        "/^playwright/",
+        "/^@playwright\\//",
+        "/^mcr\\.microsoft\\.com\\/playwright/",
+        "/^microsoft\\/playwright-github-action/"
+      ],
+      "groupName": "playwright"
+    }
+    // Add additional rules below as needed
+  ]
+}

--- a/rules-python.json5
+++ b/rules-python.json5
@@ -1,0 +1,162 @@
+// WARNING: This file is deprecated. It has been consolidated into default.json.
+// It is preserved here strictly for legacy repositories pinned to older config releases (like v2026.7.0).
+// DO NOT revise or maintain this file. Any rule updates should be made directly in default.json.
+//
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  // Group boto3 and botocore dependencies for easier management
+  "packageRules": [
+    // Pin Python dependencies for security
+    {
+      "description": "Pin Python dependencies: Pin all digests/SHAs for supply chain security. This ensures reproducible builds and prevents dependency substitution attacks.",
+      "matchManagers": [
+        "pip_requirements",
+        "pip_setup",
+        "pipenv",
+        "poetry",
+        "uv",
+        "pep621",
+        "pip-compile"
+      ],
+      "pinDigests": true
+    },
+    {
+      "description": "Group Python ecosystem: Combine updates from all Python managers (pip_requirements, pip_setup, pipenv, poetry, uv, pep621, pip-compile) into single PRs to maintain compatibility.",
+      "matchManagers": [
+        "pip_requirements",
+        "pip_setup",
+        "pipenv",
+        "poetry",
+        "uv",
+        "pep621",
+        "pip-compile"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "python dependencies",
+      "groupSlug": "python"
+    },
+    // Group boto3 and botocore dependencies for easier management
+    {
+      "description": "Group boto",
+      "groupName": "boto",
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
+      "matchPackageNames": ["/^boto3$/", "/^botocore$/"]
+    },
+    // Group all pytest-related dependencies for unified update PRs
+    {
+      "description": "Group pytest",
+      "groupName": "pytest",
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
+      "matchPackageNames": [
+        "/^pytest$/",
+        "/^pytest-/",
+        "/^coverage$/",
+        "/^tox$/",
+        "/^mock$/",
+        "/^factory-boy$/",
+        "/^freezegun$/"
+      ]
+    },
+    // Group SQLAlchemy and related tools for easier upgrades
+    {
+      "description": "Group sqlalchemy",
+      "groupName": "sqlalchemy",
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
+      "matchPackageNames": [
+        "/^sqlalchemy$/",
+        "/^sqlmodel$/",
+        "/^sqlacodegen$/",
+        "/^mock-alchemy$/",
+        "/^alembic$/"
+      ]
+    },
+    // Group linters and formatters
+    {
+      "description": "Group python linters",
+      "groupName": "python linters",
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
+      "matchPackageNames": [
+        "/^ruff$/",
+        "/^black$/",
+        "/^isort$/",
+        "/^pylint$/",
+        "/^flake8$/",
+        "/^mypy$/",
+        "/^bandit$/",
+        "/^pre-commit$/"
+      ]
+    },
+    // Group pydantic and its core components
+    {
+      "description": "Group pydantic",
+      "groupName": "pydantic",
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
+      "matchPackageNames": [
+        "/^pydantic$/",
+        "/^pydantic-core$/",
+        "/^annotated-types$/"
+      ]
+    },
+    // Group FastAPI and related web stack components
+    {
+      "description": "Group fastapi stack",
+      "groupName": "fastapi stack",
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
+      "matchPackageNames": [
+        "/^fastapi$/",
+        "/^starlette$/",
+        "/^python-multipart$/",
+        "/^uvicorn$/",
+        "/^gunicorn$/",
+        "/^httpx$/",
+        "/^anyio$/"
+      ]
+    },
+    // Group AI and Machine Learning dependencies
+    {
+      "description": "Group ai-ml",
+      "groupName": "ai-ml",
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
+      "matchPackageNames": [
+        "/^huggingface-hub$/",
+        "/^tokenizers$/",
+        "/^hf-xet$/",
+        "/^onnxruntime$/",
+        "/^openai$/",
+        "/^langchain/",
+        "/^llama-index/"
+      ]
+    },
+    // Group core data science libraries
+    {
+      "description": "Group data science",
+      "groupName": "data science",
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
+      "matchPackageNames": [
+        "/^numpy$/",
+        "/^pandas$/",
+        "/^scipy$/",
+        "/^matplotlib$/",
+        "/^seaborn$/",
+        "/^scikit-learn$/"
+      ]
+    },
+    // Group python development tools
+    {
+      "description": "Group python tools",
+      "groupName": "python tools",
+      "matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "uv", "pep621", "pip-compile"],
+      "matchPackageNames": [
+        "/^uv$/",
+        "/^setuptools$/",
+        "/^tomlkit$/",
+        "/^orjson$/",
+        "/^pip$/",
+        "/^pip-tools$/"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
Commit c99aa0523fa7992a89535081e6ef7301cee9815b consolidated language rule files into `default.json` and deleted the original `.json5` preset files (`rules-infra`, `rules-java`, `rules-javascript`, and `rules-python`).

However, downstream repositories pinned to older versions of `bcgov/renovate-config` (such as `2026.7.0`) still reference these files via nested, unpinned presets (e.g. `github>bcgov/renovate-config:rules-infra.json5`). Because Renovate resolves these unpinned nested presets against the default branch (`main`), they crash with resolution errors now that the files are deleted on `main`.

## Solution
This PR restores the deleted `.json5` preset files with their pre-consolidation contents so that legacy repositories remain fully functional.

Each file now includes a clear comment warning that it is deprecated, consolidated into `default.json`, and must not be revised or maintained going forward. Once downstream teams have upgraded their configuration references, these files can be safely deleted.