### PR TITLE
feat: change lockfile maintenance schedule to weekly

### DIFF
--- a/default.json
+++ b/default.json
@@ -42,7 +42,7 @@
     "group:recommended",
     ":combinePatchMinorReleases",
     ":enableVulnerabilityAlerts",
-    ":maintainLockFilesMonthly",
+    ":maintainLockFilesWeekly",
     ":preserveSemverRanges",
     ":rebaseStalePrs",
     ":semanticCommits",


### PR DESCRIPTION
Updates default Renovate configuration preset to schedule lockfile maintenance on a weekly cadence (`:maintainLockFilesWeekly`) rather than monthly (`:maintainLockFilesMonthly`).