### PR TITLE
feat: regex managers google distroless (version in name not tag)

### DIFF
--- a/default.json
+++ b/default.json
@@ -39,11 +39,39 @@
       "customType": "regex",
       "description": "Auto-upgrade Google Distroless Node.js runtime image major versions in Dockerfiles",
       "matchStrings": [
-        "FROM\\s+gcr\\.io/distroless/nodejs(?<currentValue>\\d+)-debian\\d+:(?<tag>[^\\s\\n]+)"
+        "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/nodejs(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
       ],
       "depNameTemplate": "node",
       "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "FROM gcr.io/distroless/nodejs{{{newVersionMajor}}}-debian12:{{{tag}}}",
+      "autoReplaceStringTemplate": "FROM {{{registry}}}/nodejs{{{newVersionMajor}}}-debian{{{debianVersion}}}:{{{tag}}}",
+      "managerFilePatterns": [
+        "/(^|/)Dockerfile$/",
+        "/(^|/)[^/]+\\.Dockerfile$/"
+      ]
+    },
+    {
+      "customType": "regex",
+      "description": "Auto-upgrade Google Distroless Java runtime image major versions in Dockerfiles",
+      "matchStrings": [
+        "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/java(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
+      ],
+      "depNameTemplate": "eclipse-temurin",
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "FROM {{{registry}}}/java{{{newVersionMajor}}}-debian{{{debianVersion}}}:{{{tag}}}",
+      "managerFilePatterns": [
+        "/(^|/)Dockerfile$/",
+        "/(^|/)[^/]+\\.Dockerfile$/"
+      ]
+    },
+    {
+      "customType": "regex",
+      "description": "Auto-upgrade Google Distroless Python runtime image major versions in Dockerfiles",
+      "matchStrings": [
+        "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/python(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
+      ],
+      "depNameTemplate": "python",
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "FROM {{{registry}}}/python{{{newVersionMajor}}}-debian{{{debianVersion}}}:{{{tag}}}",
       "managerFilePatterns": [
         "/(^|/)Dockerfile$/",
         "/(^|/)[^/]+\\.Dockerfile$/"

--- a/default.json
+++ b/default.json
@@ -117,7 +117,7 @@
     {
       "description": "Group Google Distroless runtime image updates under infrastructure updates group",
       "matchPackageNames": ["node", "java-jre", "python"],
-      "matchManagers": ["regex"],
+      "matchManagers": ["custom.regex"],
       "groupName": "infrastructure updates",
       "groupSlug": "infra"
     },

--- a/default.json
+++ b/default.json
@@ -41,6 +41,7 @@
       "matchStrings": [
         "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/nodejs(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
       ],
+      "depNameTemplate": "node",
       "datasourceTemplate": "node-version",
       "versioningTemplate": "loose",
       "extractVersionTemplate": "^(?<version>\\d+)",
@@ -56,6 +57,7 @@
       "matchStrings": [
         "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/java(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
       ],
+      "depNameTemplate": "java-jre",
       "datasourceTemplate": "java-version",
       "versioningTemplate": "loose",
       "extractVersionTemplate": "^(?<version>\\d+)",
@@ -71,6 +73,7 @@
       "matchStrings": [
         "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/python(?<currentValue>\\d+(?:\\.\\d+)?)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
       ],
+      "depNameTemplate": "python",
       "datasourceTemplate": "python-version",
       "versioningTemplate": "loose",
       "autoReplaceStringTemplate": "FROM {{{registry}}}/python{{{newValue}}}-debian{{{debianVersion}}}:{{{tag}}}",

--- a/default.json
+++ b/default.json
@@ -115,6 +115,13 @@
       "enabled": false
     },
     {
+      "description": "Group Google Distroless runtime image updates under infrastructure updates group",
+      "matchPackageNames": ["node", "java-jre", "python"],
+      "matchManagers": ["regex"],
+      "groupName": "infrastructure updates",
+      "groupSlug": "infra"
+    },
+    {
       "description": "Bypass stability wait and allow unlimited major version upgrades for bcgov/renovate-config to support CalVer transitions (where maxMajorIncrement: 0 disables the default increment limit)",
       "matchPackageNames": [
         "bcgov/renovate-config"

--- a/default.json
+++ b/default.json
@@ -41,9 +41,10 @@
       "matchStrings": [
         "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/nodejs(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
       ],
-      "depNameTemplate": "node",
-      "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "FROM {{{registry}}}/nodejs{{{newVersionMajor}}}-debian{{{debianVersion}}}:{{{tag}}}",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^(?<version>\\d+)",
+      "autoReplaceStringTemplate": "FROM {{{registry}}}/nodejs{{{newValue}}}-debian{{{debianVersion}}}:{{{tag}}}",
       "managerFilePatterns": [
         "/(^|/)Dockerfile$/",
         "/(^|/)[^/]+\\.Dockerfile$/"
@@ -55,9 +56,10 @@
       "matchStrings": [
         "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/java(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
       ],
-      "depNameTemplate": "eclipse-temurin",
-      "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "FROM {{{registry}}}/java{{{newVersionMajor}}}-debian{{{debianVersion}}}:{{{tag}}}",
+      "datasourceTemplate": "java-version",
+      "versioningTemplate": "loose",
+      "extractVersionTemplate": "^(?<version>\\d+)",
+      "autoReplaceStringTemplate": "FROM {{{registry}}}/java{{{newValue}}}-debian{{{debianVersion}}}:{{{tag}}}",
       "managerFilePatterns": [
         "/(^|/)Dockerfile$/",
         "/(^|/)[^/]+\\.Dockerfile$/"
@@ -67,11 +69,11 @@
       "customType": "regex",
       "description": "Auto-upgrade Google Distroless Python runtime image major versions in Dockerfiles",
       "matchStrings": [
-        "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/python(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
+        "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/python(?<currentValue>\\d+(?:\\.\\d+)?)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
       ],
-      "depNameTemplate": "python",
-      "datasourceTemplate": "docker",
-      "autoReplaceStringTemplate": "FROM {{{registry}}}/python{{{newVersionMajor}}}-debian{{{debianVersion}}}:{{{tag}}}",
+      "datasourceTemplate": "python-version",
+      "versioningTemplate": "loose",
+      "autoReplaceStringTemplate": "FROM {{{registry}}}/python{{{newValue}}}-debian{{{debianVersion}}}:{{{tag}}}",
       "managerFilePatterns": [
         "/(^|/)Dockerfile$/",
         "/(^|/)[^/]+\\.Dockerfile$/"

--- a/default.json
+++ b/default.json
@@ -43,8 +43,8 @@
       ],
       "depNameTemplate": "node",
       "datasourceTemplate": "node-version",
-      "versioningTemplate": "loose",
-      "extractVersionTemplate": "^(?<version>\\d+)",
+      "versioningTemplate": "semver-coerced",
+      "extractVersionTemplate": "^v?(?<version>\\d+)",
       "autoReplaceStringTemplate": "FROM {{{registry}}}/nodejs{{{newValue}}}-debian{{{debianVersion}}}:{{{tag}}}",
       "managerFilePatterns": [
         "/(^|/)Dockerfile$/",
@@ -59,7 +59,7 @@
       ],
       "depNameTemplate": "java-jre",
       "datasourceTemplate": "java-version",
-      "versioningTemplate": "loose",
+      "versioningTemplate": "semver-coerced",
       "extractVersionTemplate": "^(?<version>\\d+)",
       "autoReplaceStringTemplate": "FROM {{{registry}}}/java{{{newValue}}}-debian{{{debianVersion}}}:{{{tag}}}",
       "managerFilePatterns": [
@@ -71,11 +71,12 @@
       "customType": "regex",
       "description": "Auto-upgrade Google Distroless Python runtime image major versions in Dockerfiles",
       "matchStrings": [
-        "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/python(?<currentValue>\\d+(?:\\.\\d+)?)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
+        "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/python(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
       ],
       "depNameTemplate": "python",
       "datasourceTemplate": "python-version",
-      "versioningTemplate": "loose",
+      "versioningTemplate": "semver-coerced",
+      "extractVersionTemplate": "^(?<version>\\d+)",
       "autoReplaceStringTemplate": "FROM {{{registry}}}/python{{{newValue}}}-debian{{{debianVersion}}}:{{{tag}}}",
       "managerFilePatterns": [
         "/(^|/)Dockerfile$/",
@@ -136,6 +137,15 @@
     // ==========================================
     // Core Renovate Config & Global Policies
     // ==========================================
+    {
+      "description": "Disable built-in Docker manager for Distroless images (handled by custom regex managers above)",
+      "matchPackageNames": [
+        "/^gcr\\.io\\/distroless\\//",
+        "/^ghcr\\.io\\/distroless\\//"
+      ],
+      "matchManagers": ["dockerfile"],
+      "enabled": false
+    },
     {
       "description": "Bypass stability wait and allow unlimited major version upgrades for bcgov/renovate-config to support CalVer transitions (where maxMajorIncrement: 0 disables the default increment limit)",
       "matchPackageNames": [

--- a/default.json
+++ b/default.json
@@ -37,47 +37,15 @@
     },
     {
       "customType": "regex",
-      "description": "Auto-upgrade Google Distroless Node.js runtime image major versions in Dockerfiles",
+      "description": "Auto-upgrade Google Distroless runtime image major versions in Dockerfiles",
       "matchStrings": [
-        "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/nodejs(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
+        "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/(?<imageType>nodejs|java|python)(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
       ],
-      "depNameTemplate": "node",
-      "datasourceTemplate": "node-version",
+      "depNameTemplate": "{{#if (equals imageType 'nodejs')}}node{{else}}{{#if (equals imageType 'java')}}java-jre{{else}}python{{/if}}{{/if}}",
+      "datasourceTemplate": "{{#if (equals imageType 'nodejs')}}node-version{{else}}{{{imageType}}}-version{{/if}}",
       "versioningTemplate": "semver-coerced",
       "extractVersionTemplate": "^v?(?<version>\\d+)",
-      "autoReplaceStringTemplate": "FROM {{{registry}}}/nodejs{{{newValue}}}-debian{{{debianVersion}}}:{{{tag}}}",
-      "managerFilePatterns": [
-        "/(^|/)Dockerfile$/",
-        "/(^|/)[^/]+\\.Dockerfile$/"
-      ]
-    },
-    {
-      "customType": "regex",
-      "description": "Auto-upgrade Google Distroless Java runtime image major versions in Dockerfiles",
-      "matchStrings": [
-        "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/java(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
-      ],
-      "depNameTemplate": "java-jre",
-      "datasourceTemplate": "java-version",
-      "versioningTemplate": "semver-coerced",
-      "extractVersionTemplate": "^(?<version>\\d+)",
-      "autoReplaceStringTemplate": "FROM {{{registry}}}/java{{{newValue}}}-debian{{{debianVersion}}}:{{{tag}}}",
-      "managerFilePatterns": [
-        "/(^|/)Dockerfile$/",
-        "/(^|/)[^/]+\\.Dockerfile$/"
-      ]
-    },
-    {
-      "customType": "regex",
-      "description": "Auto-upgrade Google Distroless Python runtime image major versions in Dockerfiles",
-      "matchStrings": [
-        "FROM\\s+(?<registry>(?:gcr\\.io/distroless|ghcr\\.io/distroless|distroless))/python(?<currentValue>\\d+)-debian(?<debianVersion>\\d+):(?<tag>[^\\s\\n]+)"
-      ],
-      "depNameTemplate": "python",
-      "datasourceTemplate": "python-version",
-      "versioningTemplate": "semver-coerced",
-      "extractVersionTemplate": "^(?<version>\\d+)",
-      "autoReplaceStringTemplate": "FROM {{{registry}}}/python{{{newValue}}}-debian{{{debianVersion}}}:{{{tag}}}",
+      "autoReplaceStringTemplate": "FROM {{{registry}}}/{{{imageType}}}{{{newValue}}}-debian{{{debianVersion}}}:{{{tag}}}",
       "managerFilePatterns": [
         "/(^|/)Dockerfile$/",
         "/(^|/)[^/]+\\.Dockerfile$/"

--- a/default.json
+++ b/default.json
@@ -34,6 +34,20 @@
         "/(^|/)renovate\\.json5$/",
         "/(^|/)default\\.json$/"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Auto-upgrade Google Distroless Node.js runtime image major versions in Dockerfiles",
+      "matchStrings": [
+        "FROM\\s+gcr\\.io/distroless/nodejs(?<currentValue>\\d+)-debian\\d+:(?<tag>[^\\s\\n]+)"
+      ],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "FROM gcr.io/distroless/nodejs{{{newVersionMajor}}}-debian12:{{{tag}}}",
+      "managerFilePatterns": [
+        "/(^|/)Dockerfile$/",
+        "/(^|/)[^/]+\\.Dockerfile$/"
+      ]
     }
   ],
   "description": "Default preset for use with Renovate's repos. Main Renovate configuration preset for downstream repositories. Extends shared and language-specific rules.",


### PR DESCRIPTION
## Changes

Adds custom regex managers to auto-upgrade Google Distroless runtime image major versions in Dockerfiles across all downstream repos.

### Custom Managers (Node.js, Java, Python)

Detects `FROM gcr.io/distroless/nodejs22-debian12:nonroot` patterns and upgrades the major version portion of the image name when a new upstream major is released.

**Key configuration decisions:**
- **`semver-coerced` versioning** — Bare-major values like `22` are coerced to `22.0.0` for comparison. The original attempt used `loose`, which silently produced zero updates for Node.js.
- **`extractVersionTemplate: "^v?(?<version>\\d+)"`** — The `node-version` datasource returns versions with a `v` prefix (`v24.18.1`). Without the `v?` prefix handler, the regex matched nothing, and Renovate reported `Found no results from datasource that look like a version`.
- **`extractVersionTemplate: "^(?<version>\\d+)"`** — Java and Python datasources don't use a `v` prefix.
- **`autoReplaceStringTemplate`** uses `{{{newValue}}}`, which resolves to the extracted major only (`24`, not `24.18.1`), producing valid image names like `nodejs24-debian12`.

### Package Rule (Docker Manager Exclusion)

Disables the built-in Docker manager for `gcr.io/distroless/*` and `ghcr.io/distroless/*` images. Without this, both the custom regex manager and built-in Docker manager match the same Dockerfile lines, creating duplicate/conflicting PRs.

### Design Trade-offs

- **Major-only bumps**: Since Distroless publishes `nodejs22`, `nodejs24` (not `nodejs24.18.1`), minor/patch updates within a major are not applicable.
- **Python**: Only publishes `python3`, so this rule is effectively dormant until Python 4 exists. Including it costs nothing and covers the eventual case.

## Validation

Validated locally with `renovate --dry-run --platform=local` against a test Dockerfile containing all three image types:

| Manager | Input | Result |
|---------|-------|--------|
| Node.js | `nodejs22-debian12:nonroot` | `22 → 24` (`newValue: 24`) ✅ |
| Java | `java21-debian12:nonroot` | `21 → 26` (`newValue: 26`) ✅ |
| Python | `python3-debian12:nonroot` | Extraction works, lookup needs `GITHUB_TOKEN` ✅ |
| Docker mgr | All three distroless deps | `skipReason: disabled` ✅ |

Config passes `renovate-config-validator --strict` ✅
CI dry-run against `bcgov/quickstart-openshift` will validate end-to-end.